### PR TITLE
Create highlight group for string delimiters

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -118,9 +118,10 @@ hi def link     goEscapeError       Error
 
 " Strings and their contents
 syn cluster     goStringGroup       contains=goEscapeOctal,goEscapeC,goEscapeX,goEscapeU,goEscapeBigU,goEscapeError
-syn region      goString            start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
-syn region      goRawString         start=+`+ end=+`+
+syn region      goString            matchgroup=goStringDelimiter start=+"+ skip=+\\\\\|\\"+ end=+"+ contains=@goStringGroup
+syn region      goRawString         matchgroup=goStringDelimiter start=+`+ end=+`+
 
+hi def link     goStringDelimiter   String
 hi def link     goString            String
 hi def link     goRawString         String
 


### PR DESCRIPTION
Some users wish to highlight string delimiters (e.g., quotation marks) in a different color from the body of the string itself. This feature is provided by several other languages' syntax highlighting rules, and is easy to achieve for Go as well.

Add a match group for the string delimiters and by default, assign it to the same highlight as the rest of the string, to preserve existing behavior. Users who wish to make use of this feature need only adjust their color scheme files to link the new goStringDelimiter group to their preferred syntax highlighting group.