### PR TITLE
syntax: Allow lone 0 as number

### DIFF
--- a/syntax/go.vim
+++ b/syntax/go.vim
@@ -135,7 +135,7 @@ syn region      goBlock             start="{" end="}" transparent fold
 syn region      goParen             start='(' end=')' transparent
 
 " Integers
-syn match       goDecimalInt        "\<[1-9][0-9_]*\([Ee]\d\+\)\?\>"
+syn match       goDecimalInt        "\<0\|[1-9][0-9_]*\([Ee]\d\+\)\?\>"
 syn match       goHexadecimalInt    "\<0x[0-9A-F_]\+\>"
 syn match       goOctalInt          "\<0\o\+\>"
 syn match       goOctalError        "\<0\o*[89]\d*\>"


### PR DESCRIPTION
Previous change fixed numeric separators in numbers, but broke lone zero as
being recognized as a number